### PR TITLE
Removing extra " in yaml

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ humandate: "19-20 June, 2017"    # human-readable dates for the workshop (e.g., 
 humantime: "9:00 am - 4:30 pm"    # human-readable times for the workshop (e.g., "9:00 am - 4:30 pm")
 startdate: 2017-06-19      # machine-readable start date for the workshop in YYYY-MM-DD format like 2015-01-01
 enddate: 2017-06-20        # machine-readable end date for the workshop in YYYY-MM-DD format like 2015-01-02
-instructor: ["Belinda Weaver, "Jonah Duckles""] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
+instructor: ["Belinda Weaver, "Jonah Duckles"] # boxed, comma-separated list of instructors' names as strings, like ["Kay McNulty", "Betty Jennings", "Betty Snyder"]
 helper: ["Carmi Cronje"]     # boxed, comma-separated list of helpers' names, like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"]
 contact: "b.weaver@uq.edu.au"      # contact email address for host, lead instructor, or whoever else is handling questions
 etherpad:             # optional: URL for the workshop Etherpad if there is one


### PR DESCRIPTION
The page isn't displaying properly with the yaml header not parsing right. This should fix it I think.